### PR TITLE
Add auto-preview feature

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -34,7 +34,7 @@ func TestParseContent(t *testing.T) {
 func TestRun(t *testing.T) {
 	var mockStdOut bytes.Buffer
 
-	if err := run(inputFile, &mockStdOut); err != nil {
+	if err := run(inputFile, &mockStdOut, true); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
We should save the user having to manual open the output file, and instead automatically open it. If this d¥behaviour is not desired, the user can pass the -s flag to skip the auto-preview.