### PR TITLE
Remove tmp file when previewed

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"os/exec"
 	"runtime"
@@ -64,6 +65,8 @@ func run(filename string, out io.Writer, skipPreview bool) error {
 		return nil
 	}
 
+	defer os.Remove(outName)
+
 	return preview(outName)
 }
 
@@ -116,5 +119,9 @@ func preview(fName string) error {
 	}
 
 	// Open the file using default program
-	return exec.Command(cPath, cParams...).Run()
+	err = exec.Command(cPath, cParams...).Run()
+
+	// Give the browser some time to open the file before deleting it
+	time.Sleep(2 * time.Second)
+	return err
 }


### PR DESCRIPTION
We can remove the tmp file once opened by the browser to preview filling up the tmp directory with many files.